### PR TITLE
Typo fix, achievend -> achieved

### DIFF
--- a/types/steamapi/index.d.ts
+++ b/types/steamapi/index.d.ts
@@ -179,7 +179,7 @@ declare class Achievement {
     api: string;
     name: string;
     description: string;
-    achievend: boolean;
+    achieved: boolean;
     unlockTime: number;
 
     get unlockedAt(): Date;


### PR DESCRIPTION
I found and fixed a typo in the steamapi typings.